### PR TITLE
Fixed Doctrine serialization

### DIFF
--- a/src/TreeHouse/Queue/Message/Serializer/DoctrineSerializer.php
+++ b/src/TreeHouse/Queue/Message/Serializer/DoctrineSerializer.php
@@ -28,22 +28,21 @@ class DoctrineSerializer implements SerializerInterface
     }
 
     /**
-     * @param integer|object $value
+     * @param object $value
+     *
+     * @throws \InvalidArgumentException When $value is not a Doctrine object
      *
      * @return array
      */
     protected function getIdentifierValues($value)
     {
-        // if a raw identifier is passed, return it in an array.
-        // this would be the same if we passed in an object with that id
-        if (is_numeric($value)) {
-            return [intval($value)];
+        if (!is_object($value)) {
+            throw new \InvalidArgumentException('Only Doctrine objects can be serialized');
         }
 
-        $class    = get_class($value);
+        $class = get_class($value);
         $metadata = $this->doctrine->getManager()->getClassMetadata($class);
-        $id       = $metadata->getIdentifierValues($value);
 
-        return array_values($id);
+        return $metadata->getIdentifierValues($value);
     }
 }

--- a/tests/TreeHouse/Queue/Tests/Message/Serializer/DoctrineSerializerTest.php
+++ b/tests/TreeHouse/Queue/Tests/Message/Serializer/DoctrineSerializerTest.php
@@ -22,24 +22,32 @@ class DoctrineSerializerTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf(DoctrineSerializer::class, $serializer);
     }
 
-    /**
-     * @dataProvider getTestData
-     *
-     * @param mixed  $value
-     * @param string $expected
-     */
-    public function testSerialize($value, $expected)
+    public function testSerialize()
     {
+        $object = new ObjectMock(1234);
+
         $serializer = new DoctrineSerializer($this->doctrine);
-        $this->assertEquals($expected, $serializer->serialize($value));
+        $this->assertEquals('{"id":1234}', $serializer->serialize($object));
     }
 
-    public function getTestData()
+    /**
+     * @dataProvider getInvalidTestData
+     * @expectedException \InvalidArgumentException
+     *
+     * @param mixed $value
+     */
+    public function testInvalidArgument($value)
+    {
+        $serializer = new DoctrineSerializer($this->doctrine);
+        $serializer->serialize($value);
+    }
+
+    public function getInvalidTestData()
     {
         return [
-            [2, "[2]"],   // assume integers are identifiers
-            ["2", "[2]"], // cast numeric values to integers
-            [new ObjectMock(1234), "[1234]"]
+            [1234],
+            ['1234'],
+            [[1234]],
         ];
     }
 


### PR DESCRIPTION
Only using the array values from Doctrine object identifiers means losing essential information, which you need if you want to look up these objects again. This PR fixes this.