### PR TITLE
Exchanges and queues are no longer declared automatically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ For a complete list of releases, see the [releases page][0].
   instances, which are only for composing new messages.
 * Removed `MessageProvider` and its interface, as it was basically a copy of
   the consumer class. Instead, consumers now work directly with a queue/processor.
+* Exchanges and queues are no longer declared automatically on factory creation
 
 
 ## v0.1.0

--- a/src/TreeHouse/Queue/Amqp/Driver/Amqp/AmqpFactory.php
+++ b/src/TreeHouse/Queue/Amqp/Driver/Amqp/AmqpFactory.php
@@ -37,9 +37,9 @@ class AmqpFactory implements FactoryInterface
             $connection->connect();
         }
 
-        $channel = new \AMQPChannel($connection->getDelegate());
+        $delegate = new \AMQPChannel($connection->getDelegate());
 
-        return new Channel($channel, $connection);
+        return new Channel($delegate, $connection);
     }
 
     /**
@@ -52,15 +52,13 @@ class AmqpFactory implements FactoryInterface
         $flags = null,
         array $args = []
     ) {
-        $exchange = new \AMQPExchange($channel->getDelegate());
-        $exchange->setName($name);
-        $exchange->setType($type);
-        $exchange->setFlags(Exchange::convertToDelegateFlags($flags));
-        $exchange->setArguments($args);
+        $delegate = new \AMQPExchange($channel->getDelegate());
+        $delegate->setName($name);
+        $delegate->setType($type);
+        $delegate->setFlags(Exchange::convertToDelegateFlags($flags));
+        $delegate->setArguments($args);
 
-        $exchange->declareExchange();
-
-        return new Exchange($exchange, $channel);
+        return new Exchange($delegate, $channel);
     }
 
     /**
@@ -68,16 +66,14 @@ class AmqpFactory implements FactoryInterface
      */
     public function createQueue(ChannelInterface $channel, $name = null, $flags = null, array $args = [])
     {
-        $queue = new \AMQPQueue($channel->getDelegate());
-        $queue->setFlags(Queue::convertToDelegateFlags($flags));
-        $queue->setArguments($args);
+        $delegate = new \AMQPQueue($channel->getDelegate());
+        $delegate->setFlags(Queue::convertToDelegateFlags($flags));
+        $delegate->setArguments($args);
 
         if (null !== $name) {
-            $queue->setName($name);
+            $delegate->setName($name);
         }
 
-        $queue->declareQueue();
-
-        return new Queue($queue, $channel);
+        return new Queue($delegate, $channel);
     }
 }

--- a/tests/TreeHouse/Queue/Tests/Amqp/Driver/AbstractDriverEnvelopeTest.php
+++ b/tests/TreeHouse/Queue/Tests/Amqp/Driver/AbstractDriverEnvelopeTest.php
@@ -52,7 +52,11 @@ abstract class AbstractDriverEnvelopeTest extends \PHPUnit_Framework_TestCase
         ];
 
         $exchange = $this->getExchange();
+        $exchange->declareExchange();
+
         $queue = $this->getQueue();
+        $queue->declareQueue();
+
         $queue->bind($exchange->getName(), $routingKey);
 
         $exchange->publish($body, $routingKey, null, $properties);

--- a/tests/TreeHouse/Queue/Tests/Amqp/Driver/AbstractDriverExchangeTest.php
+++ b/tests/TreeHouse/Queue/Tests/Amqp/Driver/AbstractDriverExchangeTest.php
@@ -43,6 +43,9 @@ abstract class AbstractDriverExchangeTest extends \PHPUnit_Framework_TestCase
 
         $exchange1 = $this->factory->createExchange($channel, 'exchg1');
         $exchange2 = $this->factory->createExchange($channel, 'exchg2');
+        $exchange1->declareExchange();
+        $exchange2->declareExchange();
+
         $routingKey = 'test';
 
         $this->assertTrue($exchange1->bind($exchange2->getName(), $routingKey));
@@ -71,6 +74,7 @@ abstract class AbstractDriverExchangeTest extends \PHPUnit_Framework_TestCase
         $conn = $this->factory->createConnection('localhost');
         $channel = $this->factory->createChannel($conn);
         $exchange = $this->factory->createExchange($channel, 'exchg1');
+        $exchange->declareExchange();
 
         $conn->close();
 
@@ -105,6 +109,9 @@ abstract class AbstractDriverExchangeTest extends \PHPUnit_Framework_TestCase
         $channel = $this->factory->createChannel($conn);
         $exchange1 = $this->factory->createExchange($channel, 'exchg1');
         $exchange2 = $this->factory->createExchange($channel, 'exchg2');
+
+        $exchange1->declareExchange();
+        $exchange2->declareExchange();
 
         $exchange1->bind($exchange2->getName(), 'test');
 

--- a/tests/TreeHouse/Queue/Tests/Processor/Retry/RetryProcessorTest.php
+++ b/tests/TreeHouse/Queue/Tests/Processor/Retry/RetryProcessorTest.php
@@ -72,6 +72,8 @@ class RetryProcessorTest extends \PHPUnit_Framework_TestCase
         $inner->shouldReceive('process')->once()->andThrow($exception);
 
         $envelope = $this->createEnvelopeMock(1);
+        $envelope->shouldReceive('getDeliveryTag')->andReturnNull();
+
         $result = $processor->process($envelope);
 
         $this->assertTrue($result, 'The ->process() method should return the value from the strategy');
@@ -90,6 +92,7 @@ class RetryProcessorTest extends \PHPUnit_Framework_TestCase
 
         // create message for second attempt
         $envelope = $this->createEnvelopeMock(2);
+        $envelope->shouldReceive('getDeliveryTag')->andReturnNull();
 
         $processor = new RetryProcessor($inner, $strategy);
         $processor->setMaxAttempts(2);


### PR DESCRIPTION
This is because sometimes you have to work with an exchange/queue that you don't have configure rights to, but can read from (or write to).